### PR TITLE
Use REDIS_URL instead of REDIS_DB_PARAM env var

### DIFF
--- a/src/robot.configure.ts
+++ b/src/robot.configure.ts
@@ -9,6 +9,6 @@ export function configureRobot() {
 }
 
 function configureDB() {
-  Container.set(REDIS, new IORedis(process.env.REDIS_DB_PARAM));
+  Container.set(REDIS, new IORedis(process.env.REDIS_URL));
   console.info('Connected to Database...');
 }


### PR DESCRIPTION
# Read carefully

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior (if this is a feature change)?**
Now a `db index` parameter was added to the REDIS_URL env var. In addition, this env var is been used (instead of REDIS_DB_PARAM) to configure the IORedis client.

**Other information**: